### PR TITLE
Potential fix for code scanning alert no. 2: Unnecessary use of `cat` process

### DIFF
--- a/assets/code/javascript/splash.js
+++ b/assets/code/javascript/splash.js
@@ -2,13 +2,13 @@ import { BrowserWindow } from 'electron'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import https from 'https'
-import { execSync } from 'child_process'
+import fs from 'fs'
 
 function getPackageExtension() {
   if (process.env.SNAP) return 'snap'
   if (process.platform === 'linux') {
     try {
-      const osRelease = execSync('cat /etc/os-release').toString().toLowerCase()
+      const osRelease = fs.readFileSync('/etc/os-release').toString().toLowerCase()
       if (osRelease.includes('arch')) return 'pacman'
       if (osRelease.includes('fedora') || osRelease.includes('centos') || osRelease.includes('red hat')) return 'rpm'
       if (osRelease.includes('debian') || osRelease.includes('ubuntu')) return 'deb'


### PR DESCRIPTION
Potential fix for [https://github.com/dvytvs/Ruscord-linux-version/security/code-scanning/2](https://github.com/dvytvs/Ruscord-linux-version/security/code-scanning/2)

To fix the issue, replace the use of `execSync('cat /etc/os-release')` with `fs.readFileSync('/etc/os-release')`. This change eliminates the need for spawning a child process and ensures the code is simpler, more efficient, and portable across platforms. The `fs.readFileSync` method reads the file directly and returns its contents as a buffer, which can be converted to a string using `.toString()`.

**Steps to implement the fix:**
1. Import the `fs` module at the top of the file if it is not already imported.
2. Replace the `execSync('cat /etc/os-release')` call with `fs.readFileSync('/etc/os-release')`.
3. Ensure the `.toString()` method is applied to the result of `fs.readFileSync` to maintain the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
